### PR TITLE
Remove old hacks and handle end of audio correctly.

### DIFF
--- a/Generator.h
+++ b/Generator.h
@@ -31,9 +31,6 @@ public:
     int  m_zerocount;
     qint64 bytes_left;
 
-signals:
-    void generatorDone();
-
 public slots:
     void restartData();
 
@@ -43,10 +40,6 @@ public slots:
 private:
     int putShort(char *t, unsigned int value);
     int fillData(char *start, int frequency, float seconds);
-
-    bool isGenerating;
 };
-
-
 
 #endif // GENERATOR_H

--- a/Morse.h
+++ b/Morse.h
@@ -119,8 +119,7 @@ public slots:
     void playSequence();
     QTime maybePlaySequence(bool addPause = false);
 
-    void generatorDone();
-    void audioFinished(QAudio::State newState);
+    void audioStateChanged(QAudio::State newState);
     void keyPressed(QString newtext);
     void keyPressed(QChar key);
     void keyReleased(QString newtext);

--- a/modes/MorseMode.cpp
+++ b/modes/MorseMode.cpp
@@ -83,11 +83,7 @@ void MorseMode::handleKeyRelease(const QString &letterReleased) {
     handleKeyRelease(letterReleased[0]);
 }
 
-void MorseMode::audioFinished(QAudio::State state) {
-    if (state != QAudio::IdleState && state != QAudio::StoppedState)
-        return;
-
-    // qDebug() << "audio state changed: " << state << ", old state = " << m_morse->audioMode();
+void MorseMode::audioFinished() {
 
     if (m_morse->audioMode() != Morse::STOPPED) {
         audioStopped();

--- a/modes/MorseMode.h
+++ b/modes/MorseMode.h
@@ -110,7 +110,7 @@ public slots:
 
     virtual void help();                 // opens a help window to show helpText() contents
 
-    virtual void audioFinished(QAudio::State state);  // changes the internal state and calls:
+    virtual void audioFinished();                     // changes the internal state and calls:
     virtual void audioStopped();                      // this when audio has stopped playing
 
     virtual void changeWPM(int wpm);                  // call this to change the WPM rate


### PR DESCRIPTION
The correct way in Qt to find out when audio playback has finished is to
connect to the stateChanged signal of the QAudioOutput and look for a
transition to QAudio::IdleState.

It seems that in the past, this didn't always work correctly on some
platforms. As a workaround, CuteCW was using its own 'generatorDone'
signal as an alternative way to get an event at the end of playback.

However, the generatorDone signal only indicates when the last sample
has been read from the generator, not when it has actually been played
out by the audio device. The audio driver may read samples from the
input to buffer them well before they are actually played. As such,
users have sometimes encountered playback being truncated. There have
been some attempts to fix this by adding padding to the buffer, but this
is not a reliable approach.

This commit simply assumes that the old platform specific bugs are long
gone by now. It uses the correct way to handle end of playback, and gets
rid of the generatorDone signal and other related tricks.

This change fixes truncated playback for me with Qt 5.11 on Linux. It
should work for all other platforms too, as long as Qt works correctly.